### PR TITLE
Add support for IntelliJ 2021.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A plugin for **Intellij** based IDEs to draw rectangle on the editor's gutter de
 
 Clicking on the color icon from the gutter will open a color picker dialog to modify the color.
 
-Only those property satisfying the following pattern will be highlighted.
+Only the properties satisfying the following pattern will be highlighted:
 
 ```kotlin
 $modifier $name = Color($int)

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 
 pluginGroup = com.github.kaustubhpatange.composecolor
-pluginName_ = Highlight Colors for Compose
+pluginName_ = Compose Color Highlighter
 pluginVersion = 0.0.6
 pluginSinceBuild = 202
 pluginUntilBuild = 213.*

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,13 +5,13 @@ pluginGroup = com.github.kaustubhpatange.composecolor
 pluginName_ = Highlight Colors for Compose
 pluginVersion = 0.0.5
 pluginSinceBuild = 202
-pluginUntilBuild = 211.*
+pluginUntilBuild = 213.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2020.2.4, 2020.3.4, 2021.1.1
+pluginVerifierIdeVersions = 2020.2.4, 2020.3.4, 2021.1.1, 2021.3.3
 
 platformType = IC
-platformVersion = 2020.2.4
+platformVersion = 2021.3.3
 platformDownloadSources = true
 # Plugin Dependencies -> https://www.jetbrains.org/intellij/sdk/docs/basics/plugin_structure/plugin_dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://www.jetbrains.org/intellij/sdk/docs/reference_guide/intellij_artifacts.html
 
 pluginGroup = com.github.kaustubhpatange.composecolor
-pluginName_ = Compose Color Highlighter
+pluginName_ = Highlight Colors for Compose
 pluginVersion = 0.0.6
 pluginSinceBuild = 202
 pluginUntilBuild = 213.*

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = com.github.kaustubhpatange.composecolor
 pluginName_ = Highlight Colors for Compose
-pluginVersion = 0.0.5
+pluginVersion = 0.0.6
 pluginSinceBuild = 202
 pluginUntilBuild = 213.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin url="https://github.com/KaustubhPatange/compose-color">
     <id>com.github.kaustubhpatange.composecolor</id>
     <name>Highlight Colors for Compose</name>
-    <version>0.0.5</version>
+    <version>0.0.6</version>
     <vendor url="https://github.com/KaustubhPatange">Kaustubh Patange</vendor>
 
     <description><![CDATA[

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -5,23 +5,40 @@
     <vendor url="https://github.com/KaustubhPatange">Kaustubh Patange</vendor>
 
     <description><![CDATA[
-        Draws rectangle on editor's gutter denoting the color represented by <pre>androidx.compose.ui.graphics.Color</pre><br/>
+        Draws rectangle on editor's gutter denoting the color represented by <code>androidx.compose.ui.graphics.Color</code><br/>
         Clicking on the color icon from the gutter will open a color picker dialog to modify the color.
+        <br><br>
+        <a href="https://github.com/KaustubhPatange/compose-color">GitHub</a> | <a href="https://github.com/KaustubhPatange/compose-color/issues">Issues</a>
     ]]></description>
 
     <change-notes><![CDATA[
-        <b>0.0.5</b>
-        - Support for non-floating points RGBA.
-        - Support for IDEA 2021+.
-        <b>0.0.4</b>
-        - Added support for Color(r,g,b,a).
-        <b>0.0.3</b>
-        - Improved: Color modifying strategy.
-        <b>0.0.2</b>
-        - Fixed: Issue with modifying color on non-writable files.
-        <b>0.0.1</b>
-        - Initial release
-        - Open-sourced on Github
+        <h4>0.0.6</h4>
+        <ul>
+            <li>Added: Support for IDEA 2021.3.3+.</li>
+            <li>Improved: Plugin info.</li>
+        </ul>
+        <h4>0.0.5</h4>
+        <ul>
+            <li>Added: Support for non-floating points RGBA.</li>
+            <li>Added: Support for IDEA 2021+.</li>
+        </ul>
+        <h4>0.0.4</h4>
+        <ul>
+            <li>Added: support for Color(r,g,b,a).</li>
+        </ul>
+        <h4>0.0.3</h4>
+        <ul>
+            <li>Improved: Color modifying strategy.</li>
+        </ul>
+        <h4>0.0.2</h4>
+        <ul>
+            <li>Fixed: Issue with modifying color on non-writable files.</li>
+        </ul>
+        <h4>0.0.1</h4>
+        <ul>
+            <li>Initial release</li>
+            <li>Open-sourced on Github</li>
+        </ul>
         ]]>
     </change-notes>
 


### PR DESCRIPTION
Closes #3 

I added support for IntelliJ 2021.3.3 and tested by:

1. Built the plugin locally `gradle buildPlugin`
2. Located the `.zip` artifact in `build/distributions`
3. Installed it manually in IntelliJ 2021.3.3 → `Preferences` → `Plugins` → `⚙️` → `Install plugin from disk...`.

⬆️ Same tests steps from above can be used to test the PR.


### Other Small Fixes
1. Bumped the version number to `0.0.6`
2. Fixed the formatting in the `Change Notes`.
3. Fixed some minor spelling and formatting mistakes in the `README` file.
4. Proposing to rename the plugin to `Compose Color Highlighter`
   → **Motivation**: It is listed nicer and closer to the other installed plugins for Compose in the IDE:

<img width="1168" alt="Screenshot 2022-04-07 at 19 44 02" src="https://user-images.githubusercontent.com/4588074/162264597-910a2e5d-aeb5-4b35-aad2-ec6db4fbcd91.png">

